### PR TITLE
Refactor functions marked terminating

### DIFF
--- a/Authorization/Owner.juvix
+++ b/Authorization/Owner.juvix
@@ -83,11 +83,10 @@ isAuthorizedByOwner
              (AuthMessage.mustBeCreated msg)
              tx;
 
-terminating
-containsNonOwner (keys : List PublicKey) (owner : PublicKey) : Maybe PublicKey :=
-  case keys of
-    | nil := nothing
-    | (k :: ks) :=
-      if
-        | k /= owner := just k
-        | else := containsNonOwner ks owner;
+containsNonOwner
+  (owner : PublicKey) : List PublicKey -> Maybe PublicKey
+  | nil := nothing
+  | (k :: ks) :=
+    if
+      | k /= owner := just k
+      | else := containsNonOwner owner ks;

--- a/Token/Label.juvix
+++ b/Token/Label.juvix
@@ -51,15 +51,13 @@ getDecimals (r : Resource) : Nat :=
 getSupply (r : Resource) : Supply :=
   Label.supply (getLabel r);
 
-terminating
 containsWrongLabel
-  (labels : List Label) (label : Label) : Maybe Label :=
-  case labels of
-    | nil := nothing
-    | l :: ls :=
-      if
-        | l /= label := just l
-        | else := containsWrongLabel ls label;
+  (label : Label) : List Label -> Maybe Label
+  | nil := nothing
+  | (l :: ls) :=
+    if
+      | l /= label := just l
+      | else := containsWrongLabel label ls;
 
 type InvalidLabelError :=
   mkInvalidLabelError {

--- a/Token/Transaction.juvix
+++ b/Token/Transaction.juvix
@@ -153,9 +153,9 @@ merge
       consumedRs : List Resource := tokens;
       createdRs : List Resource := [merged];
       extraData : Map Bytes32 Bytes := mkAuthExtraData mySecret consumedRs createdRs;
-    in case containsWrongLabel (map getLabel tokens) label of
+    in case containsWrongLabel label (map getLabel tokens) of
       | just wrongLabel := throw mkInvalidLabelError@{expected := label; actual := wrongLabel}
       | nothing :=
-     case containsNonOwner (map getOwner tokens) owner of
+     case containsNonOwner owner (map getOwner tokens) of
         | just notOwner := throw mkUnauthorizedError@{expected := myself; actual := notOwner}
         | nothing := pass (mkTransaction mySecret consumedRs createdRs extraData);


### PR DESCRIPTION
`containsNonOwner` and `containsWrongLabel` needed to be marked `terminating` because the termination checker cannot see through the case expression.

This refactor removes the outer case expression from the respective function body so that `terminating` is not required.