### PR TITLE
fix: remove non-ascii characters

### DIFF
--- a/AnomaHelpers.juvix
+++ b/AnomaHelpers.juvix
@@ -49,7 +49,7 @@ instance
 InsufficientElementsError-Show
   : Show InsufficientElementsError :=
   mkShow
-    λ {e :=
+    \ {e :=
       "InsufficientElementsError:\n{"
         ++str "limit : "
         ++str (e |> InsufficientElementsError.limit |> Show.show)
@@ -68,7 +68,7 @@ instance
 InsufficientQuantityError-Show
   : Show InsufficientQuantityError :=
   mkShow
-    λ {e :=
+    \ {e :=
       "InsufficientQuantityError:\n{"
         ++str "limit : "
         ++str (e |> InsufficientQuantityError.limit |> Show.show)
@@ -86,7 +86,7 @@ type InvalidLogicError :=
 instance
 InvalidLogicError-Show : Show InvalidLogicError :=
   mkShow
-    λ {e :=
+    \ {e :=
       "InvalidLogicError:\n{"
         ++str "expected : "
         ++str (e |> InvalidLogicError.expected |> Show.show)

--- a/Authorization/Owner.juvix
+++ b/Authorization/Owner.juvix
@@ -28,7 +28,7 @@ type UnauthorizedError :=
 instance
 UnauthorizedError-Show : Show UnauthorizedError :=
   mkShow
-    λ {e :=
+    \ {e :=
       "UnauthorizedError:\n{"
         ++str "expected : "
         ++str (e |> UnauthorizedError.expected |> Show.show)

--- a/Token/Error.juvix
+++ b/Token/Error.juvix
@@ -17,7 +17,7 @@ type TokenError :=
 
 instance
 TokenError-Show : Show TokenError :=
-  mkShow λ {e := "TokenError:\n" ++str Show.show e};
+  mkShow \ {e := "TokenError:\n" ++str Show.show e};
 
 trait
 type TokenThrowable Error Result :=

--- a/Token/Label.juvix
+++ b/Token/Label.juvix
@@ -28,7 +28,7 @@ Label-Eq : Eq Label :=
 instance
 Label-Show : Show Label :=
   mkShow
-    λ {l :=
+    \ {l :=
       "{"
         ++str "name : "
         ++str (l |> Label.name |> Show.show)
@@ -76,7 +76,7 @@ type InvalidLabelError :=
 instance
 InvalidLabelError-Show : Show InvalidLabelError :=
   mkShow
-    λ {e :=
+    \ {e :=
       "InvalidLabelError:\n{"
         ++str "expected : "
         ++str (e |> InvalidLabelError.expected |> Show.show)

--- a/Token/Supply.juvix
+++ b/Token/Supply.juvix
@@ -20,7 +20,7 @@ Supply-Eq : Eq Supply :=
 instance
 Supply-Show : Show Supply :=
   mkShow
-    λ {
+    \ {
       | Unbound := "Unbound"
       | Capped := "Capped"
       | Fixed := "Fixed"


### PR DESCRIPTION
Non-ascii characters result in LaTeX not being able to display the code in listings