### PR TITLE
AppLib.juvix exports everything needed

### DIFF
--- a/Anoma.juvix
+++ b/Anoma.juvix
@@ -8,3 +8,5 @@ import Anoma.Delta open using {Delta} public;
 import Anoma.Random open public;
 import Anoma.Utils as Utils public;
 import Anoma.Encode open public;
+import Anoma.State.CommitmentTree open public;
+import Anoma.Builtin.System open using {isNullifier; isCommitment} public;

--- a/Applib.juvix
+++ b/Applib.juvix
@@ -1,6 +1,18 @@
 module Applib;
 
+import Anoma open hiding {
+  kind;
+  nullifier;
+  commitment;
+  module ExternalIdentity;
+  module InternalIdentity;
+} public;
+import Anoma.Builtin.System open using {builtinAnomaDecode; builtinAnomaEncode} public;
+
+import BaseLayer open public;
+
 import Applib.Helpers open public;
 import Applib.Identities open public;
 import Applib.Authorization as Authorization public;
 import Applib.Trait.Tx open public;
+

--- a/BaseLayer.juvix
+++ b/BaseLayer.juvix
@@ -1,0 +1,4 @@
+module BaseLayer;
+
+import BaseLayer.ResourceMachine open public;
+import BaseLayer.TransactionRequest open public;


### PR DESCRIPTION
`AppLib.juvix` now exports more things. In order to write anoma applications it should be sufficient to import only `Applib` (and the juvix stdlib prelude). It shouldn't be required for the user to import any module of the form `Applib.*`, `Anoma.*` or `BaseLayer.*`.