### PR TITLE
fix: swap intent logic bug

### DIFF
--- a/Applib/Intent/Swap/Logic.juvix
+++ b/Applib/Intent/Swap/Logic.juvix
@@ -38,7 +38,7 @@ swapIntentLogic
            | nothing := false
            | just self :=
              case HasEphemerality.get self of
-               | NonEphemeral := true
+               | NonEphemeral := false
                | Ephemeral :=
                  let
                    created := Logic.Witness.created privateInputs;


### PR DESCRIPTION
Non-ephemeral swap intent resources are not allowed and could be exploited to settle the transaction without giving the wanted resources to the user.

This PR fixes this vulnerability.