### PR TITLE
Fix the type signature of resource logic

### DIFF
--- a/BaseLayer/ResourceMachine.juvix
+++ b/BaseLayer/ResourceMachine.juvix
@@ -158,7 +158,7 @@ with
       isConsumed : Bool;
       consumed : List Resource;
       created : List Resource;
-      appData : AppData;
+      appData : List AppData.Value;
     }
   with
     nullifiers (a : Args) : List Nullifier :=


### PR DESCRIPTION
Resource Logics do not take AppData they take the AppData Values in a list