### PR TITLE
Change appData name in Logic.Args

### DIFF
--- a/BaseLayer/ResourceMachine.juvix
+++ b/BaseLayer/ResourceMachine.juvix
@@ -159,7 +159,7 @@ with
       isConsumed : Bool;
       consumed : List Resource;
       created : List Resource;
-      appData : List AppData.Value;
+      data : List AppData.Value;
     }
   with
     nullifiers (a : Args) : List Nullifier :=


### PR DESCRIPTION
Changes `appData` in `Logic.Args` to `data`, avoiding confusion with the `AppData` type.
